### PR TITLE
Add backend test harness and update documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+server/node/node_modules/
+coverage/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -33,6 +33,20 @@ Analytics events are only persisted when visitors accept cookies via the consent
 4. Update the `<meta name="consult-backend">` tag in the HTML (or set `window.__CONSULT_BACKEND__`) when deploying to production so the frontend analytics and booking flows point to your live backend domain.
 5. Configure Stripe webhooks to call `https://YOUR_BACKEND/stripe/webhook` and update Google Calendar / n8n credentials in the environment file.
 
+## Testing & quality checks
+
+The backend exposes a modular Express application (`server/node/app.js`) so that the business logic can be exercised without starting the HTTP server. Vitest and Supertest cover the analytics APIs, Neo4j bootstrapper, and helper utilities.
+
+Run the automated test suite from `server/node`:
+
+```bash
+cd server/node
+npm install
+npm run test
+```
+
+Use `npm run test:watch` for an interactive watch mode while iterating locally. The coverage report is written to the terminal and `coverage/` directory (LCOV) for CI integration.
+
 ## CI/CD
 
 GitHub Actions (`.github/workflows/ci.yml`) lint the backend and render the Compose configuration on every push/PR. Extend the workflow with integration tests as services evolve.

--- a/server/node/app.js
+++ b/server/node/app.js
@@ -1,0 +1,304 @@
+import express from 'express';
+import bodyParser from 'body-parser';
+import cors from 'cors';
+
+export function addMinutes(dateStr, timeStr, minutes) {
+  const dt = new Date(`${dateStr}T${timeStr}:00`);
+  dt.setMinutes(dt.getMinutes() + minutes);
+  return dt.toISOString();
+}
+
+export async function ensureGraphSetup({ neo4jDriver, neo4jDatabase, logger = console }) {
+  if (!neo4jDriver) {
+    logger.warn('Neo4j configuration missing – analytics endpoints disabled.');
+    return;
+  }
+
+  try {
+    await neo4jDriver.executeQuery(
+      'CREATE CONSTRAINT IF NOT EXISTS FOR (v:Visitor) REQUIRE v.sessionId IS UNIQUE',
+      {},
+      { database: neo4jDatabase }
+    );
+    await neo4jDriver.executeQuery(
+      'CREATE CONSTRAINT IF NOT EXISTS FOR (e:Event) REQUIRE e.id IS UNIQUE',
+      {},
+      { database: neo4jDatabase }
+    );
+    logger.log('Neo4j analytics constraints ensured.');
+  } catch (err) {
+    logger.error('Failed to prepare Neo4j constraints', err);
+  }
+}
+
+export function createApp({
+  config,
+  stripe,
+  calendar,
+  auth,
+  fetchImpl,
+  neo4jDriver,
+  neo4jDatabase,
+  logger = console
+}) {
+  const fetchFn = fetchImpl || (typeof fetch !== 'undefined' ? fetch : null);
+
+  const app = express();
+  const origin = config.origin ? config.origin.split(',') : true;
+  app.use(cors({ origin }));
+  app.use(bodyParser.json({ verify: (req, res, buf) => {
+    req.rawBody = buf;
+  }}));
+
+  app.post('/stripe/checkout', async (req, res) => {
+    try {
+      const { company, name, email, date, time, focus, notes } = req.body || {};
+      const session = await stripe.checkout.sessions.create({
+        mode: 'payment',
+        payment_method_types: ['card'],
+        customer_email: email,
+        line_items: [{
+          price_data: {
+            currency: 'usd',
+            unit_amount: 10000,
+            product_data: { name: `Intro Consultation (${focus || 'General'})` }
+          },
+          quantity: 1
+        }],
+        success_url: config.successUrl,
+        cancel_url: config.cancelUrl,
+        metadata: {
+          company,
+          name,
+          email,
+          date,
+          time,
+          focus,
+          notes: (notes || '').slice(0, 4500)
+        }
+      });
+      res.json({ url: session.url });
+    } catch (e) {
+      logger.error(e);
+      res.status(500).json({ error: e.message });
+    }
+  });
+
+  app.post('/stripe/subscription', async (req, res) => {
+    try {
+      const { email, company, name, focus, notes } = req.body || {};
+      const session = await stripe.checkout.sessions.create({
+        mode: 'subscription',
+        customer_email: email,
+        line_items: [{ price: config.stripeRetainerPriceId, quantity: 1 }],
+        allow_promotion_codes: true,
+        success_url: config.stripeSuccessSubUrl,
+        cancel_url: config.stripeCancelSubUrl,
+        metadata: {
+          company,
+          name,
+          email,
+          focus,
+          notes: (notes || '').slice(0, 4500)
+        }
+      });
+      res.json({ url: session.url });
+    } catch (e) {
+      logger.error(e);
+      res.status(500).json({ error: e.message });
+    }
+  });
+
+  app.post('/stripe/portal', async (req, res) => {
+    try {
+      const { email } = req.body || {};
+      const customers = await stripe.customers.list({ email, limit: 1 });
+      const customer = customers.data[0] || await stripe.customers.create({ email });
+      const portal = await stripe.billingPortal.sessions.create({
+        customer: customer.id,
+        return_url: config.stripeSuccessSubUrl
+      });
+      res.json({ url: portal.url });
+    } catch (e) {
+      logger.error(e);
+      res.status(500).json({ error: e.message });
+    }
+  });
+
+  app.post('/stripe/webhook', bodyParser.raw({ type: 'application/json' }), async (req, res) => {
+    let event;
+    try {
+      event = stripe.webhooks.constructEvent(
+        req.body,
+        req.headers['stripe-signature'],
+        config.stripeWebhookSecret
+      );
+    } catch (err) {
+      logger.error('Webhook error', err.message);
+      return res.status(400).send(`Webhook Error: ${err.message}`);
+    }
+
+    if (event.type === 'checkout.session.completed') {
+      const session = event.data.object;
+      if (session.mode === 'payment') {
+        const md = session.metadata || {};
+        try {
+          await auth.authorize();
+          const timeZone = config.timezone || 'America/New_York';
+          const endISO = addMinutes(md.date, md.time, 25);
+          await calendar.events.insert({
+            auth,
+            calendarId: config.googleCalendarId,
+            requestBody: {
+              summary: `Intro Call: ${md.company || 'New Client'}`,
+              description: `Requester: ${md.name} <${md.email}>
+Focus: ${md.focus}
+Notes:
+${md.notes || ''}`,
+              start: { dateTime: `${md.date}T${md.time}:00`, timeZone },
+              end: { dateTime: endISO, timeZone },
+              attendees: [{ email: md.email }],
+              location: config.meetLink || ''
+            }
+          });
+
+          if (config.n8nPostCallWebhook && fetchFn) {
+            const followupAt = new Date(endISO);
+            followupAt.setMinutes(followupAt.getMinutes() + 5);
+            await fetchFn(config.n8nPostCallWebhook, {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({
+                email: md.email,
+                name: md.name,
+                company: md.company,
+                focus: md.focus,
+                followup_at: followupAt.toISOString(),
+                retainer_link: config.retainerLink || 'https://YOUR_DOMAIN/site/pay/retainer.html',
+                proposal_link: config.proposalLink || 'https://YOUR_DOMAIN/proposal/proposal.html'
+              })
+            });
+          }
+        } catch (e) {
+          logger.error('Calendar or n8n post-call failed', e);
+        }
+      }
+    }
+
+    if ([
+      'customer.subscription.created',
+      'invoice.paid',
+      'invoice.payment_failed',
+      'customer.subscription.updated',
+      'customer.subscription.deleted'
+    ].includes(event.type)) {
+      logger.log('Subscription event:', event.type);
+    }
+
+    res.json({ received: true });
+  });
+
+  app.post('/analytics/events', async (req, res) => {
+    if (!neo4jDriver) {
+      return res.status(503).json({ error: 'Analytics storage not configured' });
+    }
+
+    const { eventType, sessionId, page = null, properties = {} } = req.body || {};
+    if (!eventType || !sessionId) {
+      return res.status(400).json({ error: 'eventType and sessionId are required' });
+    }
+
+    if (typeof properties !== 'object' || Array.isArray(properties)) {
+      return res.status(400).json({ error: 'properties must be an object' });
+    }
+
+    const timestamp = new Date().toISOString();
+
+    try {
+      await neo4jDriver.executeQuery(
+        `MERGE (v:Visitor {sessionId: $sessionId})
+         ON CREATE SET v.firstSeen = datetime($timestamp)
+         SET v.lastSeen = datetime($timestamp)
+         CREATE (e:Event {
+           id: randomUUID(),
+           type: $eventType,
+           page: $page,
+           timestamp: datetime($timestamp),
+           properties: $properties
+         })
+         MERGE (v)-[:PERFORMED]->(e)`,
+        { sessionId, eventType, page, timestamp, properties },
+        { database: neo4jDatabase }
+      );
+      res.json({ ok: true });
+    } catch (err) {
+      logger.error('Failed to persist analytics event', err);
+      res.status(500).json({ error: 'Failed to persist analytics event' });
+    }
+  });
+
+  app.post('/client/companion', async (req, res) => {
+    const { message } = req.body || {};
+    if (!message) {
+      return res.status(400).json({ error: 'Message is required' });
+    }
+
+    if (config.companionWebhook && fetchFn) {
+      try {
+        const response = await fetchFn(config.companionWebhook, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ message })
+        });
+        if (!response.ok) {
+          throw new Error(`Companion webhook failed (${response.status})`);
+        }
+        const data = await response.json();
+        return res.json({ reply: data.reply || 'Response received.' });
+      } catch (err) {
+        logger.error('Companion webhook error', err);
+        return res.status(502).json({ error: 'Companion service error' });
+      }
+    }
+
+    res.json({ reply: 'Your workspace is ready once the companion backend URL is configured.' });
+  });
+
+  app.get('/analytics/metrics', async (req, res) => {
+    if (!neo4jDriver) {
+      return res.status(503).json({ error: 'Analytics storage not configured' });
+    }
+
+    try {
+      const [visitorsResult, conversionsResult, eventsResult] = await Promise.all([
+        neo4jDriver.executeQuery(
+          'MATCH (v:Visitor) RETURN count(v) AS visitors',
+          {},
+          { database: neo4jDatabase }
+        ),
+        neo4jDriver.executeQuery(
+          "MATCH (:Visitor)-[:PERFORMED]->(e:Event { type: 'conversion' }) RETURN count(e) AS conversions",
+          {},
+          { database: neo4jDatabase }
+        ),
+        neo4jDriver.executeQuery(
+          'MATCH (:Visitor)-[:PERFORMED]->(e:Event) RETURN count(e) AS totalEvents',
+          {},
+          { database: neo4jDatabase }
+        )
+      ]);
+
+      const visitors = visitorsResult.records?.[0]?.get('visitors') || 0;
+      const conversions = conversionsResult.records?.[0]?.get('conversions') || 0;
+      const totalEvents = eventsResult.records?.[0]?.get('totalEvents') || 0;
+      const conversionRate = visitors ? Number((conversions / visitors).toFixed(3)) : 0;
+
+      res.json({ visitors, conversions, totalEvents, conversionRate });
+    } catch (err) {
+      logger.error('Failed to load analytics metrics', err);
+      res.status(500).json({ error: 'Failed to load analytics metrics' });
+    }
+  });
+
+  return app;
+}

--- a/server/node/index.js
+++ b/server/node/index.js
@@ -1,17 +1,32 @@
 import 'dotenv/config';
-import express from 'express';
-import bodyParser from 'body-parser';
-import cors from 'cors';
 import Stripe from 'stripe';
 import { google } from 'googleapis';
 import fetch from 'node-fetch';
 import neo4j from 'neo4j-driver';
 
-const app = express();
-app.use(cors({ origin: process.env.ORIGIN?.split(',') || true }));
-app.use(bodyParser.json({ verify: (req, res, buf) => { req.rawBody = buf; }}));
+import { createApp, ensureGraphSetup } from './app.js';
 
-const neo4jConfigured = Boolean(process.env.NEO4J_URI && process.env.NEO4J_USER && process.env.NEO4J_PASSWORD);
+const config = {
+  origin: process.env.ORIGIN || '',
+  successUrl: process.env.SUCCESS_URL,
+  cancelUrl: process.env.CANCEL_URL,
+  stripeRetainerPriceId: process.env.STRIPE_RETAINER_PRICE_ID,
+  stripeSuccessSubUrl: process.env.STRIPE_SUCCESS_SUB_URL,
+  stripeCancelSubUrl: process.env.STRIPE_CANCEL_SUB_URL,
+  stripeWebhookSecret: process.env.STRIPE_WEBHOOK_SECRET,
+  timezone: process.env.TIMEZONE || 'America/New_York',
+  googleCalendarId: process.env.GOOGLE_CALENDAR_ID,
+  meetLink: process.env.MEET_LINK || '',
+  n8nPostCallWebhook: process.env.N8N_POST_CALL_WEBHOOK,
+  companionWebhook: process.env.COMPANION_WEBHOOK,
+  retainerLink: process.env.RETAINER_LINK,
+  proposalLink: process.env.PROPOSAL_LINK,
+  port: process.env.PORT || 8081
+};
+
+const neo4jConfigured = Boolean(
+  process.env.NEO4J_URI && process.env.NEO4J_USER && process.env.NEO4J_PASSWORD
+);
 const neo4jDatabase = process.env.NEO4J_DATABASE || undefined;
 const neo4jDriver = neo4jConfigured
   ? neo4j.driver(
@@ -21,33 +36,10 @@ const neo4jDriver = neo4jConfigured
     )
   : null;
 
-async function ensureGraphSetup() {
-  if (!neo4jDriver) {
-    console.warn('Neo4j configuration missing – analytics endpoints disabled.');
-    return;
-  }
-  try {
-    await neo4jDriver.executeQuery(
-      'CREATE CONSTRAINT IF NOT EXISTS FOR (v:Visitor) REQUIRE v.sessionId IS UNIQUE',
-      {},
-      { database: neo4jDatabase }
-    );
-    await neo4jDriver.executeQuery(
-      'CREATE CONSTRAINT IF NOT EXISTS FOR (e:Event) REQUIRE e.id IS UNIQUE',
-      {},
-      { database: neo4jDatabase }
-    );
-    console.log('Neo4j analytics constraints ensured.');
-  } catch (err) {
-    console.error('Failed to prepare Neo4j constraints', err);
-  }
-}
-
-ensureGraphSetup();
+await ensureGraphSetup({ neo4jDriver, neo4jDatabase });
 
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY, { apiVersion: '2024-06-20' });
 
-// Google Calendar auth
 const calendar = google.calendar('v3');
 const auth = new google.auth.JWT(
   process.env.GOOGLE_CLIENT_EMAIL,
@@ -56,246 +48,20 @@ const auth = new google.auth.JWT(
   ['https://www.googleapis.com/auth/calendar']
 );
 
-function addMinutes(dateStr, timeStr, minutes) {
-  const dt = new Date(`${dateStr}T${timeStr}:00`);
-  dt.setMinutes(dt.getMinutes() + minutes);
-  return dt.toISOString();
-}
-
-// Create one-time intro checkout
-app.post('/stripe/checkout', async (req, res) => {
-  try {
-    const { company, name, email, date, time, focus, notes } = req.body;
-    const session = await stripe.checkout.sessions.create({
-      mode: 'payment',
-      payment_method_types: ['card'],
-      customer_email: email,
-      line_items: [{
-        price_data: {
-          currency: 'usd',
-          unit_amount: 10000,
-          product_data: { name: `Intro Consultation (${focus || 'General'})` }
-        },
-        quantity: 1
-      }],
-      success_url: process.env.SUCCESS_URL,
-      cancel_url: process.env.CANCEL_URL,
-      metadata: { company, name, email, date, time, focus, notes: (notes || '').slice(0, 4500) }
-    });
-    res.json({ url: session.url });
-  } catch (e) {
-    console.error(e);
-    res.status(500).json({ error: e.message });
-  }
+const app = createApp({
+  config,
+  stripe,
+  calendar,
+  auth,
+  fetchImpl: fetch,
+  neo4jDriver,
+  neo4jDatabase
 });
 
-// Create monthly retainer subscription checkout
-app.post('/stripe/subscription', async (req, res) => {
-  try {
-    const { email, company, name, focus, notes } = req.body;
-    const session = await stripe.checkout.sessions.create({
-      mode: 'subscription',
-      customer_email: email,
-      line_items: [{ price: process.env.STRIPE_RETAINER_PRICE_ID, quantity: 1 }],
-      allow_promotion_codes: true,
-      success_url: process.env.STRIPE_SUCCESS_SUB_URL,
-      cancel_url: process.env.STRIPE_CANCEL_SUB_URL,
-      metadata: { company, name, email, focus, notes: (notes || '').slice(0, 4500) }
-    });
-    res.json({ url: session.url });
-  } catch (e) {
-    console.error(e);
-    res.status(500).json({ error: e.message });
-  }
-});
-
-// Billing portal
-app.post('/stripe/portal', async (req, res) => {
-  try {
-    const { email } = req.body;
-    const customers = await stripe.customers.list({ email, limit: 1 });
-    const customer = customers.data[0] || await stripe.customers.create({ email });
-    const portal = await stripe.billingPortal.sessions.create({
-      customer: customer.id,
-      return_url: process.env.STRIPE_SUCCESS_SUB_URL
-    });
-    res.json({ url: portal.url });
-  } catch (e) {
-    console.error(e);
-    res.status(500).json({ error: e.message });
-  }
-});
-
-// Stripe webhook: create calendar event and schedule follow-up email via n8n
-app.post('/stripe/webhook', bodyParser.raw({ type: 'application/json' }), async (req, res) => {
-  let event;
-  try {
-    event = stripe.webhooks.constructEvent(
-      req.body,
-      req.headers['stripe-signature'],
-      process.env.STRIPE_WEBHOOK_SECRET
-    );
-  } catch (err) {
-    console.error('Webhook error', err.message);
-    return res.status(400).send(`Webhook Error: ${err.message}`);
-  }
-
-  if (event.type === 'checkout.session.completed') {
-    const session = event.data.object;
-    if (session.mode === 'payment') {
-      // Intro paid → create calendar event
-      const md = session.metadata || {};
-      try {
-        await auth.authorize();
-        const timeZone = process.env.TIMEZONE || 'America/New_York';
-        const endISO = addMinutes(md.date, md.time, 25);
-        await calendar.events.insert({
-          auth,
-          calendarId: process.env.GOOGLE_CALENDAR_ID,
-          requestBody: {
-            summary: `Intro Call: ${md.company || 'New Client'}`,
-            description: `Requester: ${md.name} <${md.email}>
-Focus: ${md.focus}
-Notes:
-${md.notes || ''}`,
-            start: { dateTime: `${md.date}T${md.time}:00`, timeZone },
-            end:   { dateTime: endISO, timeZone },
-            attendees: [{ email: md.email }],
-            location: process.env.MEET_LINK || ''
-          }
-        });
-
-        // Kick n8n: send package selection email AFTER the call ends (+5 min buffer)
-        if (process.env.N8N_POST_CALL_WEBHOOK) {
-          const followupAt = new Date(endISO);
-          followupAt.setMinutes(followupAt.getMinutes() + 5);
-          await fetch(process.env.N8N_POST_CALL_WEBHOOK, {
-            method:'POST',
-            headers:{'Content-Type':'application/json'},
-            body: JSON.stringify({
-              email: md.email, name: md.name, company: md.company, focus: md.focus,
-              followup_at: followupAt.toISOString(),
-              retainer_link: "https://YOUR_DOMAIN/site/pay/retainer.html",
-              proposal_link: "https://YOUR_DOMAIN/proposal/proposal.html"
-            })
-          });
-        }
-      } catch (e) {
-        console.error('Calendar or n8n post-call failed', e);
-      }
-    }
-  }
-
-  if (['customer.subscription.created','invoice.paid','invoice.payment_failed',
-       'customer.subscription.updated','customer.subscription.deleted'].includes(event.type)) {
-    console.log('Subscription event:', event.type);
-  }
-
-  res.json({ received: true });
-});
-
-app.post('/analytics/events', async (req, res) => {
-  if (!neo4jDriver) {
-    return res.status(503).json({ error: 'Analytics storage not configured' });
-  }
-
-  const { eventType, sessionId, page = null, properties = {} } = req.body || {};
-  if (!eventType || !sessionId) {
-    return res.status(400).json({ error: 'eventType and sessionId are required' });
-  }
-
-  if (typeof properties !== 'object' || Array.isArray(properties)) {
-    return res.status(400).json({ error: 'properties must be an object' });
-  }
-
-  const timestamp = new Date().toISOString();
-
-  try {
-    await neo4jDriver.executeQuery(
-      `MERGE (v:Visitor {sessionId: $sessionId})
-       ON CREATE SET v.firstSeen = datetime($timestamp)
-       SET v.lastSeen = datetime($timestamp)
-       CREATE (e:Event {
-         id: randomUUID(),
-         type: $eventType,
-         page: $page,
-         timestamp: datetime($timestamp),
-         properties: $properties
-       })
-       MERGE (v)-[:PERFORMED]->(e)`,
-      { sessionId, eventType, page, timestamp, properties },
-      { database: neo4jDatabase }
-    );
-    res.json({ ok: true });
-  } catch (err) {
-    console.error('Failed to persist analytics event', err);
-    res.status(500).json({ error: 'Failed to persist analytics event' });
-  }
-});
-
-app.post('/client/companion', async (req, res) => {
-  const { message } = req.body || {};
-  if (!message) {
-    return res.status(400).json({ error: 'Message is required' });
-  }
-
-  if (process.env.COMPANION_WEBHOOK) {
-    try {
-      const response = await fetch(process.env.COMPANION_WEBHOOK, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ message })
-      });
-      if (!response.ok) {
-        throw new Error(`Companion webhook failed (${response.status})`);
-      }
-      const data = await response.json();
-      return res.json({ reply: data.reply || 'Response received.' });
-    } catch (err) {
-      console.error('Companion webhook error', err);
-      return res.status(502).json({ error: 'Companion service error' });
-    }
-  }
-
-  res.json({ reply: 'Your workspace is ready once the companion backend URL is configured.' });
-});
-
-app.get('/analytics/metrics', async (req, res) => {
-  if (!neo4jDriver) {
-    return res.status(503).json({ error: 'Analytics storage not configured' });
-  }
-
-  try {
-    const [visitorsResult, conversionsResult, eventsResult] = await Promise.all([
-      neo4jDriver.executeQuery('MATCH (v:Visitor) RETURN count(v) AS visitors', {}, { database: neo4jDatabase }),
-      neo4jDriver.executeQuery(
-        "MATCH (:Visitor)-[:PERFORMED]->(e:Event { type: 'conversion' }) RETURN count(e) AS conversions",
-        {},
-        { database: neo4jDatabase }
-      ),
-      neo4jDriver.executeQuery(
-        'MATCH (:Visitor)-[:PERFORMED]->(e:Event) RETURN count(e) AS totalEvents',
-        {},
-        { database: neo4jDatabase }
-      )
-    ]);
-
-    const visitors = visitorsResult.records[0]?.get('visitors') || 0;
-    const conversions = conversionsResult.records[0]?.get('conversions') || 0;
-    const totalEvents = eventsResult.records[0]?.get('totalEvents') || 0;
-    const conversionRate = visitors ? Number((conversions / visitors).toFixed(3)) : 0;
-
-    res.json({ visitors, conversions, totalEvents, conversionRate });
-  } catch (err) {
-    console.error('Failed to load analytics metrics', err);
-    res.status(500).json({ error: 'Failed to load analytics metrics' });
-  }
-});
-
-const port = process.env.PORT || 8081;
-app.listen(port, () => console.log(`Backend listening on :${port}`));
+const server = app.listen(config.port, () => console.log(`Backend listening on :${config.port}`));
 
 const gracefulShutdown = async () => {
+  server.close();
   if (neo4jDriver) {
     await neo4jDriver.close();
   }

--- a/server/node/package.json
+++ b/server/node/package.json
@@ -4,7 +4,9 @@
   "type": "module",
   "scripts": {
     "start": "node index.js",
-    "lint": "node --check index.js"
+    "lint": "node --check index.js",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "body-parser": "^1.20.3",
@@ -15,5 +17,9 @@
     "node-fetch": "^3.3.2",
     "neo4j-driver": "^5.22.0",
     "stripe": "^16.5.0"
+  },
+  "devDependencies": {
+    "supertest": "^6.3.4",
+    "vitest": "^2.1.1"
   }
 }

--- a/server/node/test/app.test.js
+++ b/server/node/test/app.test.js
@@ -1,0 +1,190 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import request from 'supertest';
+import { addMinutes, createApp, ensureGraphSetup } from '../app.js';
+
+describe('utility helpers', () => {
+  it('addMinutes adds the requested minutes and returns ISO string', () => {
+    const base = new Date('2024-07-01T12:00:00');
+    const result = addMinutes('2024-07-01', '12:00', 30);
+    const diffMs = new Date(result).getTime() - base.getTime();
+    expect(diffMs).toBe(30 * 60 * 1000);
+  });
+});
+
+describe('ensureGraphSetup', () => {
+  it('warns when driver is missing', async () => {
+    const logger = { warn: vi.fn(), log: vi.fn(), error: vi.fn() };
+    await ensureGraphSetup({ neo4jDriver: null, neo4jDatabase: undefined, logger });
+    expect(logger.warn).toHaveBeenCalledWith('Neo4j configuration missing – analytics endpoints disabled.');
+    expect(logger.log).not.toHaveBeenCalled();
+  });
+
+  it('creates constraints when driver is configured', async () => {
+    const executeQuery = vi.fn().mockResolvedValue({});
+    const logger = { warn: vi.fn(), log: vi.fn(), error: vi.fn() };
+    await ensureGraphSetup({ neo4jDriver: { executeQuery }, neo4jDatabase: 'neo4j', logger });
+    expect(executeQuery).toHaveBeenCalledTimes(2);
+    expect(logger.log).toHaveBeenCalledWith('Neo4j analytics constraints ensured.');
+  });
+
+  it('logs an error when constraint creation fails', async () => {
+    const err = new Error('boom');
+    const executeQuery = vi.fn().mockRejectedValue(err);
+    const logger = { warn: vi.fn(), log: vi.fn(), error: vi.fn() };
+    await ensureGraphSetup({ neo4jDriver: { executeQuery }, neo4jDatabase: undefined, logger });
+    expect(logger.error).toHaveBeenCalledWith('Failed to prepare Neo4j constraints', err);
+  });
+});
+
+describe('createApp analytics endpoints', () => {
+  const baseConfig = {
+    origin: '',
+    successUrl: 'https://example.com/success',
+    cancelUrl: 'https://example.com/cancel',
+    stripeRetainerPriceId: 'price_123',
+    stripeSuccessSubUrl: 'https://example.com/sub/success',
+    stripeCancelSubUrl: 'https://example.com/sub/cancel',
+    stripeWebhookSecret: 'whsec_123',
+    timezone: 'UTC',
+    googleCalendarId: 'calendar',
+    meetLink: '',
+    n8nPostCallWebhook: '',
+    companionWebhook: '',
+    retainerLink: '',
+    proposalLink: ''
+  };
+
+  const stripe = {
+    checkout: { sessions: { create: vi.fn() } },
+    customers: {
+      list: vi.fn(),
+      create: vi.fn()
+    },
+    billingPortal: { sessions: { create: vi.fn() } },
+    webhooks: { constructEvent: vi.fn() }
+  };
+
+  const calendar = { events: { insert: vi.fn() } };
+  const auth = { authorize: vi.fn() };
+
+  let neo4jDriver;
+  let app;
+
+  beforeEach(() => {
+    neo4jDriver = {
+      executeQuery: vi.fn()
+    };
+    app = createApp({
+      config: baseConfig,
+      stripe,
+      calendar,
+      auth,
+      fetchImpl: async () => ({ ok: true, json: async () => ({ reply: 'ok' }) }),
+      neo4jDriver,
+      neo4jDatabase: 'neo4j',
+      logger: { log: vi.fn(), warn: vi.fn(), error: vi.fn() }
+    });
+  });
+
+  it('returns 503 when analytics driver is missing', async () => {
+    const localApp = createApp({
+      config: baseConfig,
+      stripe,
+      calendar,
+      auth,
+      fetchImpl: async () => ({ ok: true, json: async () => ({}) }),
+      neo4jDriver: null,
+      neo4jDatabase: undefined,
+      logger: { log: vi.fn(), warn: vi.fn(), error: vi.fn() }
+    });
+
+    await request(localApp)
+      .post('/analytics/events')
+      .send({ eventType: 'visit', sessionId: 'abc' })
+      .expect(503);
+  });
+
+  it('validates analytics payload', async () => {
+    await request(app)
+      .post('/analytics/events')
+      .send({ sessionId: 'abc' })
+      .expect(400);
+
+    await request(app)
+      .post('/analytics/events')
+      .send({ eventType: 'visit', sessionId: 'abc', properties: [] })
+      .expect(400);
+  });
+
+  it('persists analytics events', async () => {
+    neo4jDriver.executeQuery.mockResolvedValueOnce({});
+
+    await request(app)
+      .post('/analytics/events')
+      .send({ eventType: 'visit', sessionId: 'abc', properties: { ref: 'email' } })
+      .expect(200)
+      .expect('Content-Type', /json/);
+
+    expect(neo4jDriver.executeQuery).toHaveBeenCalledTimes(1);
+    const args = neo4jDriver.executeQuery.mock.calls[0];
+    expect(args[1]).toMatchObject({ eventType: 'visit', sessionId: 'abc' });
+  });
+
+  it('returns aggregated analytics metrics', async () => {
+    neo4jDriver.executeQuery
+      .mockResolvedValueOnce({ records: [{ get: () => 4 }] })
+      .mockResolvedValueOnce({ records: [{ get: () => 1 }] })
+      .mockResolvedValueOnce({ records: [{ get: () => 10 }] });
+
+    const response = await request(app).get('/analytics/metrics').expect(200);
+    expect(response.body).toEqual({
+      visitors: 4,
+      conversions: 1,
+      totalEvents: 10,
+      conversionRate: 0.25
+    });
+  });
+
+  it('handles missing companion webhook gracefully', async () => {
+    const localApp = createApp({
+      config: { ...baseConfig, companionWebhook: '' },
+      stripe,
+      calendar,
+      auth,
+      fetchImpl: async () => ({ ok: true, json: async () => ({}) }),
+      neo4jDriver,
+      neo4jDatabase: 'neo4j',
+      logger: { log: vi.fn(), warn: vi.fn(), error: vi.fn() }
+    });
+
+    const response = await request(localApp)
+      .post('/client/companion')
+      .send({ message: 'Hello' })
+      .expect(200);
+
+    expect(response.body.reply).toContain('companion backend URL is configured');
+  });
+
+  it('returns error when companion webhook fails', async () => {
+    const failingFetch = vi.fn().mockResolvedValue({ ok: false, status: 500 });
+    const logger = { log: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+    const localApp = createApp({
+      config: { ...baseConfig, companionWebhook: 'https://example.com/hook' },
+      stripe,
+      calendar,
+      auth,
+      fetchImpl: failingFetch,
+      neo4jDriver,
+      neo4jDatabase: 'neo4j',
+      logger
+    });
+
+    await request(localApp)
+      .post('/client/companion')
+      .send({ message: 'Hello' })
+      .expect(502);
+
+    expect(logger.error).toHaveBeenCalledWith('Companion webhook error', expect.any(Error));
+  });
+});

--- a/server/node/vitest.config.js
+++ b/server/node/vitest.config.js
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    coverage: {
+      reporter: ['text', 'lcov'],
+      include: ['app.js']
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- extract the Express backend into a reusable `createApp` factory with injectable dependencies and shared graph bootstrap helper
- add a Vitest/Supertest suite that covers analytics persistence, metrics aggregation, and companion webhook behaviour
- document the backend testing workflow and ignore local `node_modules` artefacts

## Testing
- npm run test *(fails: vitest not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc26e5eea48325bd09e8dea42b6abf