### PR TITLE
Update legal documents and engagement templates

### DIFF
--- a/proposal/proposal.html
+++ b/proposal/proposal.html
@@ -2,20 +2,166 @@
 <html lang="en">
 <head>
   <meta charset="utf-8" />
-  <title>Proposal – Campbell Cognition Consultants LLC</title>
+  <title>Engagement Proposal – Campbell Cognition Consultants LLC</title>
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <meta name="consult-backend" content="http://localhost:8081" />
   <link rel="stylesheet" href="/site/styles.css" />
 </head>
 <body>
-<div class='container narrow'>
-  <h1>Campbell Cognition Consultants LLC</h1>
-  <p class='muted'>Heritage-built architecture &amp; AI advisory</p>
-  <hr>
-  <h2>Engagement Proposal</h2>
-  <p>Replace with your generated HTML/PDF. This template will inherit the Campbell tartan styling when exported.</p>
-  <p class='small'>Questions? Email <a href='mailto:hello@campbellcognition.com'>hello@campbellcognition.com</a>.</p>
-</div>
+<header class="site-header">
+  <div class="container">
+    <a class="brand" href="/site/index.html">Campbell Cognition Consultants LLC</a>
+    <nav>
+      <a href="/site/offerings/index.html">Offerings</a>
+      <a href="/site/book/">Book</a>
+      <a href="/retainer/retainer.html">Retainer</a>
+      <a href="/site/legal/index.html">Legal Summary</a>
+      <a href="/site/legal/terms.html">Terms</a>
+    </nav>
+  </div>
+</header>
+<main class="container narrow">
+  <h1>Engagement Proposal</h1>
+  <p class="muted small">Updated 1 October 2024</p>
+
+  <section class="notice">
+    <h2>How to use this proposal</h2>
+    <p>This template packages the scope, investment options, delivery milestones, and legal references for a Campbell Cognition engagement. Once the selected option is approved (via signature or written acceptance), it becomes the governing statement of work and incorporates the <a href="/site/legal/terms.html">Terms &amp; Conditions</a>, <a href="/site/legal/privacy.html">Privacy Policy</a>, <a href="/site/legal/cookies.html">Cookie Notice</a>, and any applicable <a href="/retainer/retainer.html">Retainer Agreement</a>.</p>
+  </section>
+
+  <section>
+    <h2>Client &amp; project overview</h2>
+    <table class="card" style="width:100%; border-collapse:collapse;">
+      <tbody>
+        <tr>
+          <th style="text-align:left; padding:0.5rem; width:35%;">Client</th>
+          <td style="padding:0.5rem;">{{ Client legal name }}</td>
+        </tr>
+        <tr>
+          <th style="text-align:left; padding:0.5rem;">Primary contacts</th>
+          <td style="padding:0.5rem;">{{ Product owner / Sponsor / Security lead }}</td>
+        </tr>
+        <tr>
+          <th style="text-align:left; padding:0.5rem;">Engagement goals</th>
+          <td style="padding:0.5rem;">{{ Outcome-focused summary }}</td>
+        </tr>
+        <tr>
+          <th style="text-align:left; padding:0.5rem;">Success criteria</th>
+          <td style="padding:0.5rem;">{{ Quantifiable or qualitative success criteria }}</td>
+        </tr>
+      </tbody>
+    </table>
+  </section>
+
+  <section>
+    <h2>Optioned delivery plans</h2>
+    <div class="card">
+      <h3>Option A – Accelerator</h3>
+      <ul>
+        <li>Focus: {{ e.g., Architecture readiness assessment }}</li>
+        <li>Timeline: {{ e.g., 4 weeks }}</li>
+        <li>Investment: {{ e.g., $18,000 flat }}</li>
+        <li>Highlights: {{ e.g., Discovery workshops, target-state map, risk register }}</li>
+      </ul>
+    </div>
+    <div class="card" style="margin-top:1.25rem;">
+      <h3>Option B – Transformation</h3>
+      <ul>
+        <li>Focus: {{ e.g., Delivery of reference implementation }}</li>
+        <li>Timeline: {{ e.g., 10 weeks }}</li>
+        <li>Investment: {{ e.g., $45,000 in three milestones }}</li>
+        <li>Highlights: {{ e.g., Architecture runway, operating model, enablement sessions }}</li>
+      </ul>
+    </div>
+    <div class="card" style="margin-top:1.25rem;">
+      <h3>Option C – Retainer Hybrid</h3>
+      <ul>
+        <li>Focus: {{ e.g., Ongoing advisory + delivery support }}</li>
+        <li>Timeline: {{ e.g., 3-month minimum, 16 hours/month }}</li>
+        <li>Investment: {{ e.g., $6,800/month }}</li>
+        <li>Highlights: {{ e.g., Dedicated pod, backlog shaping, executive readouts }}</li>
+      </ul>
+    </div>
+  </section>
+
+  <section>
+    <h2>Milestones &amp; deliverables</h2>
+    <table class="card" style="width:100%; border-collapse:collapse;">
+      <thead>
+        <tr>
+          <th style="text-align:left; padding:0.5rem;">Milestone</th>
+          <th style="text-align:left; padding:0.5rem;">Target date</th>
+          <th style="text-align:left; padding:0.5rem;">Deliverables</th>
+          <th style="text-align:left; padding:0.5rem;">Acceptance criteria</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td style="padding:0.5rem;">{{ M1 }}</td>
+          <td style="padding:0.5rem;">{{ Date }}</td>
+          <td style="padding:0.5rem;">{{ Artifacts / workshops }}</td>
+          <td style="padding:0.5rem;">{{ Review method }}</td>
+        </tr>
+        <tr>
+          <td style="padding:0.5rem;">{{ M2 }}</td>
+          <td style="padding:0.5rem;">{{ Date }}</td>
+          <td style="padding:0.5rem;">{{ Artifacts / workshops }}</td>
+          <td style="padding:0.5rem;">{{ Review method }}</td>
+        </tr>
+        <tr>
+          <td style="padding:0.5rem;">{{ M3 }}</td>
+          <td style="padding:0.5rem;">{{ Date }}</td>
+          <td style="padding:0.5rem;">{{ Artifacts / workshops }}</td>
+          <td style="padding:0.5rem;">{{ Review method }}</td>
+        </tr>
+      </tbody>
+    </table>
+  </section>
+
+  <section>
+    <h2>Assumptions &amp; dependencies</h2>
+    <ul>
+      <li>{{ e.g., Access to sandbox environments within 5 business days }}</li>
+      <li>{{ e.g., Designate executive sponsor and product owner for decisions }}</li>
+      <li>{{ e.g., Provide prior architecture documentation before kickoff }}</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Governance &amp; communications</h2>
+    <ul>
+      <li>Weekly status report with traffic-light indicators, key decisions, and blockers.</li>
+      <li>Shared action tracker in the Campbell Companion workspace.</li>
+      <li>Escalation path: Engagement lead → Managing partner → Legal contact (<a href="mailto:legal@campbellcognition.com">legal@campbellcognition.com</a>).</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Acceptance</h2>
+    <p>Authorized representatives may approve this proposal by signing below, issuing a purchase order referencing this proposal ID, or providing written/email confirmation. Upon acceptance, the selected option becomes binding and the delivery schedule commences.</p>
+
+    <table class="card" style="width:100%; border-collapse:collapse;">
+      <tbody>
+        <tr>
+          <th style="text-align:left; padding:0.5rem;">Campbell Cognition Consultants LLC</th>
+          <th style="text-align:left; padding:0.5rem;">Client</th>
+        </tr>
+        <tr>
+          <td style="padding:0.5rem;">Name / Title: __________________________</td>
+          <td style="padding:0.5rem;">Name / Title: __________________________</td>
+        </tr>
+        <tr>
+          <td style="padding:0.5rem;">Signature: _____________________________</td>
+          <td style="padding:0.5rem;">Signature: _____________________________</td>
+        </tr>
+        <tr>
+          <td style="padding:0.5rem;">Date: _________________________________</td>
+          <td style="padding:0.5rem;">Date: _________________________________</td>
+        </tr>
+      </tbody>
+    </table>
+  </section>
+</main>
 <footer class="site-footer">
   <div class="container footer-grid">
     <div>
@@ -23,6 +169,7 @@
       <a href="mailto:hello@campbellcognition.com">hello@campbellcognition.com</a>
     </div>
     <nav>
+      <a href="/site/legal/index.html">Legal Summary</a>
       <a href="/site/legal/terms.html">Terms &amp; Conditions</a>
       <a href="/site/legal/privacy.html">Privacy Policy</a>
       <a href="/site/legal/cookies.html">Cookie Notice</a>

--- a/retainer/retainer.html
+++ b/retainer/retainer.html
@@ -2,20 +2,139 @@
 <html lang="en">
 <head>
   <meta charset="utf-8" />
-  <title>Retainer – Campbell Cognition Consultants LLC</title>
+  <title>Retainer Agreement – Campbell Cognition Consultants LLC</title>
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <meta name="consult-backend" content="http://localhost:8081" />
   <link rel="stylesheet" href="/site/styles.css" />
 </head>
 <body>
-<div class='container narrow'>
-  <h1>Campbell Cognition Consultants LLC</h1>
-  <p class='muted'>Ongoing architecture &amp; AI advisory retainer</p>
-  <hr>
-  <h2>Retainer Agreement</h2>
-  <p>Replace with your generated HTML/PDF and include Campbell Cognition branding throughout.</p>
-  <p class='small'>Need edits? Email <a href='mailto:hello@campbellcognition.com'>hello@campbellcognition.com</a>.</p>
-</div>
+<header class="site-header">
+  <div class="container">
+    <a class="brand" href="/site/index.html">Campbell Cognition Consultants LLC</a>
+    <nav>
+      <a href="/site/offerings/index.html">Offerings</a>
+      <a href="/site/book/">Book</a>
+      <a href="/proposal/proposal.html">Proposal</a>
+      <a href="/site/legal/index.html">Legal Summary</a>
+      <a href="/site/legal/terms.html">Terms</a>
+    </nav>
+  </div>
+</header>
+<main class="container narrow">
+  <h1>Retainer Agreement</h1>
+  <p class="muted small">Updated 1 October 2024</p>
+
+  <section class="notice">
+    <h2>Usage summary</h2>
+    <p>This retainer agreement (“Agreement”) sets the cadence, services, payment schedule, and expectations for ongoing advisory work between Campbell Cognition Consultants LLC (“Campbell Cognition,” “we,” “us,” or “our”) and the client organization identified in the associated order form or statement of work (“Client,” “you,” or “your”). It incorporates the <a href="/site/legal/terms.html">Terms &amp; Conditions</a>, <a href="/site/legal/privacy.html">Privacy Policy</a>, and <a href="/site/legal/cookies.html">Cookie Notice</a>.</p>
+    <ul>
+      <li><strong>Cadence:</strong> Monthly advisory pods with rolling strategic and implementation support.</li>
+      <li><strong>Allocation:</strong> Base package includes 16 consulting hours per month with optional add-on blocks.</li>
+      <li><strong>Communication:</strong> Weekly status summaries, shared task board, and direct Slack/Teams channel.</li>
+      <li><strong>Flexibility:</strong> 25% rollover buffer, ability to pause for up to 30 days with written notice.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>1. Parties &amp; Effective Date</h2>
+    <p>This Agreement is effective on the start date listed in the order form or the first day services commence, whichever occurs first. The Agreement continues on a month-to-month basis until terminated under Section 11.</p>
+  </section>
+
+  <section>
+    <h2>2. Scope of Services</h2>
+    <p>We provide the ongoing services detailed in the order form, which may include:</p>
+    <ul>
+      <li>Architecture and platform advisory for cloud, API, data, and security domains.</li>
+      <li>AI and automation integration strategy, implementation guidance, and model governance.</li>
+      <li>Workflow orchestration, n8n automation design, and operational playbooks.</li>
+      <li>Executive enablement sessions, stakeholder workshops, and documentation reviews.</li>
+    </ul>
+    <p>Any project-specific deliverables beyond the retainer scope will be captured through a supplemental statement of work.</p>
+  </section>
+
+  <section>
+    <h2>3. Cadence &amp; Collaboration</h2>
+    <ul>
+      <li>Weekly 45-minute standing sync for status, prioritization, and decision logs.</li>
+      <li>Shared task board (Notion or your selected tool) for backlog, in-flight work, and approvals.</li>
+      <li>Dedicated Slack/Teams channel with same-business-day responses during U.S. Eastern working hours.</li>
+      <li>Monthly executive summary capturing accomplishments, open risks, and next month’s focus.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>4. Time Allocation &amp; Rollover</h2>
+    <ul>
+      <li>Base retainer includes 16 hours per month. Additional hours may be purchased in 8-hour blocks at the rate listed in the order form.</li>
+      <li>Unused time automatically expires at the end of the month; up to 25% of monthly hours may roll over to the subsequent month when requested before month-end.</li>
+      <li>We maintain a shared log of consumed hours accessible through the client portal.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>5. Fees &amp; Payment</h2>
+    <ul>
+      <li>Monthly retainer fees are invoiced in advance and due within 15 calendar days of the invoice date.</li>
+      <li>Overages or pre-approved add-on blocks are invoiced in arrears with the next monthly statement.</li>
+      <li>Payments may be made via ACH, wire transfer, or credit card (3% processing fee applies to card payments).</li>
+      <li>Late payments accrue interest at 1.5% per month (or the maximum amount allowed by law if lower). We may pause services for accounts more than 15 days past due.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>6. Change Requests</h2>
+    <p>We will evaluate any requested changes to scope or cadence within two business days. Material changes may require an updated order form or supplemental statement of work. Work outside the retainer scope begins only after written approval.</p>
+  </section>
+
+  <section>
+    <h2>7. Client Responsibilities</h2>
+    <ul>
+      <li>Designate a primary point of contact with authority to prioritize work and accept deliverables.</li>
+      <li>Provide timely access to systems, documentation, and stakeholders necessary to perform services.</li>
+      <li>Inform us of compliance, security, or procurement requirements that impact delivery.</li>
+      <li>Review deliverables within five business days (unless otherwise stated). Feedback delays may affect timelines.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>8. Confidentiality &amp; Security</h2>
+    <p>Both parties will protect confidential information according to the Terms &amp; Conditions. We adhere to principle-of-least-privilege access, enforce multi-factor authentication, and use encrypted communication channels. Security incidents will be reported to your point of contact within 48 hours of confirmation.</p>
+  </section>
+
+  <section>
+    <h2>9. Intellectual Property</h2>
+    <p>Upon full payment, you receive a perpetual, worldwide, royalty-free license to use and modify deliverables created specifically for you. We retain ownership of our pre-existing materials, tools, and general know-how, and may reuse non-confidential learnings in other engagements.</p>
+  </section>
+
+  <section>
+    <h2>10. Compliance &amp; Data Processing</h2>
+    <p>We will align our work with the compliance obligations identified by you (e.g., SOC 2, HIPAA, GDPR). If a formal data processing agreement or business associate agreement is required, we will execute the appropriate addendum. We do not act as a system of record for your data.</p>
+  </section>
+
+  <section>
+    <h2>11. Term, Pause, &amp; Termination</h2>
+    <ul>
+      <li>This Agreement renews automatically each month. Either party may terminate with 30 days’ written notice after the initial three-month commitment.</li>
+      <li>You may request a pause of up to 30 consecutive days once per calendar year with 10 days’ notice. Paused months do not incur retainer fees; unused hours do not accrue during the pause.</li>
+      <li>Either party may terminate immediately for material breach that remains uncured 14 days after written notice, or for insolvency.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>12. Effect of Termination</h2>
+    <p>Upon termination, we will deliver any in-progress artifacts paid for through the effective date and provide a transition summary. Outstanding fees and approved expenses become immediately due. Each party will return or destroy confidential information per the Terms &amp; Conditions.</p>
+  </section>
+
+  <section>
+    <h2>13. Points of Contact</h2>
+    <p>Operational questions: <a href="mailto:hello@campbellcognition.com">hello@campbellcognition.com</a><br>Legal notices: <a href="mailto:legal@campbellcognition.com">legal@campbellcognition.com</a><br>Security incidents: <a href="mailto:security@campbellcognition.com">security@campbellcognition.com</a></p>
+  </section>
+
+  <section>
+    <h2>14. Acceptance</h2>
+    <p>By signing the associated order form or paying the retainer invoice, the Client acknowledges reading and agreeing to this Agreement and the incorporated policies. Digital signatures and electronic approvals are deemed originals.</p>
+  </section>
+</main>
 <footer class="site-footer">
   <div class="container footer-grid">
     <div>

--- a/site/index.html
+++ b/site/index.html
@@ -17,6 +17,7 @@
       <a href="/site/book/">Book Clarity Call</a>
       <a href="/proposal/proposal.html">Proposal</a>
       <a href="/retainer/retainer.html">Retainer</a>
+      <a href="/site/legal/index.html">Legal</a>
       <a href="/site/sign/">Sign</a>
     </nav>
   </div>

--- a/site/legal/cookies.html
+++ b/site/legal/cookies.html
@@ -12,53 +12,102 @@
   <div class="container">
     <a class="brand" href="/site/index.html">Campbell Cognition Consultants LLC</a>
     <nav>
-      <a href="/site/offerings/">Offerings</a>
+      <a href="/site/offerings/index.html">Offerings</a>
       <a href="/site/book/">Book</a>
-      <a href="/site/sign/">Sign</a>
+      <a href="/retainer/retainer.html">Retainer</a>
+      <a href="/proposal/proposal.html">Proposal</a>
+      <a href="/site/legal/index.html">Legal Summary</a>
     </nav>
   </div>
 </header>
 <main class="container narrow">
   <h1>Cookie Notice</h1>
-  <p class="muted small">Effective 30 September 2024</p>
-  <p>This Cookie Notice explains how Campbell Cognition Consultants LLC (“Campbell Cognition,” “we,” “us,” or “our”) uses cookies, pixels, and similar technologies on our website.</p>
+  <p class="muted small">Effective 1 October 2024</p>
 
-  <section>
-    <h2>1. What Are Cookies?</h2>
-    <p>Cookies are small text files placed on your device to store data that can be recalled by a web server in the domain that placed the cookie. We also use local storage to remember consent choices and session identifiers.</p>
-  </section>
-
-  <section>
-    <h2>2. Types of Cookies We Use</h2>
+  <section class="notice">
+    <h2>How cookies support our workflow</h2>
+    <p>This Cookie Notice describes how Campbell Cognition Consultants LLC (“Campbell Cognition,” “we,” “us,” or “our”) uses cookies, local storage, pixels, and similar technologies on our website and client portals.</p>
     <ul>
-      <li><strong>Essential cookies:</strong> Required to operate booking forms, retainers, and secure areas of the site.</li>
-      <li><strong>Analytics cookies:</strong> Activated only after you provide consent via our cookie banner. These cookies allow us to capture aggregated event data in Neo4j to improve funnels and user experience.</li>
-      <li><strong>Functional cookies:</strong> Used to remember your preferences (e.g., access to the Campbell Companion workspace).</li>
+      <li><strong>Essential cookies:</strong> Power booking flows, sign-in sessions, and security safeguards. These load automatically.</li>
+      <li><strong>Analytics cookies:</strong> Activate only after you grant consent through our banner and feed aggregated metrics in Neo4j.</li>
+      <li><strong>Your control:</strong> Manage preferences from the banner, clear browser storage, or email <a href="mailto:privacy@campbellcognition.com">privacy@campbellcognition.com</a>.</li>
     </ul>
   </section>
 
   <section>
+    <h2>1. What Are Cookies &amp; Similar Technologies?</h2>
+    <p>Cookies are small text files stored on your device by a website. We also use HTML5 local storage, session storage, and tracking pixels to remember preferences, secure sessions, and measure conversions.</p>
+  </section>
+
+  <section>
+    <h2>2. Cookies We Use</h2>
+    <p>The table below summarizes the cookies and storage keys we rely on.</p>
+    <table class="card" style="width:100%; border-collapse:collapse;">
+      <thead>
+        <tr>
+          <th style="text-align:left; padding:0.5rem;">Name</th>
+          <th style="text-align:left; padding:0.5rem;">Purpose</th>
+          <th style="text-align:left; padding:0.5rem;">Type</th>
+          <th style="text-align:left; padding:0.5rem;">Retention</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td style="padding:0.5rem;">ccc_session</td>
+          <td style="padding:0.5rem;">Maintains secure booking and portal sessions.</td>
+          <td style="padding:0.5rem;">Essential</td>
+          <td style="padding:0.5rem;">Session</td>
+        </tr>
+        <tr>
+          <td style="padding:0.5rem;">ccc_consent</td>
+          <td style="padding:0.5rem;">Records your analytics consent decision.</td>
+          <td style="padding:0.5rem;">Preference (local storage)</td>
+          <td style="padding:0.5rem;">12 months</td>
+        </tr>
+        <tr>
+          <td style="padding:0.5rem;">ccc_analytics_id</td>
+          <td style="padding:0.5rem;">Assigns a pseudonymous ID for consented analytics events stored in Neo4j.</td>
+          <td style="padding:0.5rem;">Analytics</td>
+          <td style="padding:0.5rem;">6 months</td>
+        </tr>
+        <tr>
+          <td style="padding:0.5rem;">stripe_mid</td>
+          <td style="padding:0.5rem;">Facilitates secure payment checkout via Stripe.</td>
+          <td style="padding:0.5rem;">Essential (third-party)</td>
+          <td style="padding:0.5rem;">1 year</td>
+        </tr>
+        <tr>
+          <td style="padding:0.5rem;">gcl_au</td>
+          <td style="padding:0.5rem;">Measures ad conversions when applicable. Only set if you consent to analytics.</td>
+          <td style="padding:0.5rem;">Analytics (third-party)</td>
+          <td style="padding:0.5rem;">90 days</td>
+        </tr>
+      </tbody>
+    </table>
+  </section>
+
+  <section>
     <h2>3. How We Use Analytics</h2>
-    <p>When you accept analytics cookies, we assign a session identifier and track events such as page visits, CTA interactions, conversions, and companion usage. This information feeds our Neo4j analytics graph to generate metrics displayed on our site. Data is used in aggregate and is not sold.</p>
+    <p>When you accept analytics cookies, our site initializes a pseudonymous session identifier and records events such as page visits, CTA clicks, bookings, and engagement with the Campbell Companion workspace. Events are stored in Neo4j to power dashboards and funnel reporting. We review data in aggregate and do not use analytics cookies for behavioral advertising.</p>
   </section>
 
   <section>
     <h2>4. Managing Your Preferences</h2>
     <ul>
-      <li>You can accept or decline analytics cookies using the banner on our site.</li>
-      <li>You may withdraw consent by clearing your browser’s cookies and local storage or by contacting us at <a href="mailto:privacy@campbellcognition.com">privacy@campbellcognition.com</a>.</li>
-      <li>Most browsers allow you to refuse cookies or alert you when cookies are being placed. Disabling essential cookies may impact site functionality.</li>
+      <li>Interact with the on-site banner to accept or decline analytics cookies at any time.</li>
+      <li>Clear your browser cookies and local storage or use browser privacy modes to remove stored identifiers.</li>
+      <li>Contact us at <a href="mailto:privacy@campbellcognition.com">privacy@campbellcognition.com</a> for assistance or to request deletion of analytics data tied to your consent ID.</li>
     </ul>
   </section>
 
   <section>
     <h2>5. Updates</h2>
-    <p>We may update this Cookie Notice to reflect changes in law or our practices. We will revise the effective date above when updates occur.</p>
+    <p>We may update this Cookie Notice to reflect changes in technology, our analytics stack, or legal requirements. Updated versions will carry a new effective date and be posted on this page.</p>
   </section>
 
   <section>
     <h2>6. Contact</h2>
-    <p>Questions about this Cookie Notice or our analytics approach can be sent to <a href="mailto:privacy@campbellcognition.com">privacy@campbellcognition.com</a>.</p>
+    <p>Questions about this Cookie Notice or our analytics practices can be sent to <a href="mailto:privacy@campbellcognition.com">privacy@campbellcognition.com</a>.</p>
   </section>
 </main>
 <footer class="site-footer">
@@ -68,9 +117,9 @@
       <a href="mailto:hello@campbellcognition.com">hello@campbellcognition.com</a>
     </div>
     <nav>
-      <a href="/site/legal/privacy.html">Privacy Policy</a>
+      <a href="/site/legal/index.html">Legal Summary</a>
       <a href="/site/legal/terms.html">Terms &amp; Conditions</a>
-      <a href="/site/index.html">Back to Home</a>
+      <a href="/site/legal/privacy.html">Privacy Policy</a>
     </nav>
     <div>
       <strong>Proof of work</strong><br>

--- a/site/legal/index.html
+++ b/site/legal/index.html
@@ -1,0 +1,136 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Legal Summary &amp; Usage Guide – Campbell Cognition Consultants LLC</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <meta name="consult-backend" content="http://localhost:8081" />
+  <link rel="stylesheet" href="/site/styles.css" />
+</head>
+<body>
+<header class="site-header">
+  <div class="container">
+    <a class="brand" href="/site/index.html">Campbell Cognition Consultants LLC</a>
+    <nav>
+      <a href="/site/offerings/index.html">Offerings</a>
+      <a href="/site/book/">Book</a>
+      <a href="/retainer/retainer.html">Retainer</a>
+      <a href="/proposal/proposal.html">Proposal</a>
+      <a href="/site/legal/terms.html">Terms</a>
+    </nav>
+  </div>
+</header>
+<main class="container narrow">
+  <h1>Legal Summary &amp; Usage Guide</h1>
+  <p class="muted small">Updated 1 October 2024</p>
+
+  <section class="notice">
+    <h2>Quick reference</h2>
+    <p>Campbell Cognition Consultants LLC operates on a transparent document stack. Use this page to understand which document governs each step of our consulting workflow and what we expect from each other.</p>
+    <ul>
+      <li><strong>Terms &amp; Conditions:</strong> Master legal agreement covering scope, payments, IP, confidentiality, and dispute resolution.</li>
+      <li><strong>Privacy Policy:</strong> How we collect, use, and secure personal data across engagements.</li>
+      <li><strong>Cookie Notice:</strong> Consent-driven analytics and session management details.</li>
+      <li><strong>Retainer Agreement:</strong> Monthly advisory cadence, deliverable expectations, and communication rhythm.</li>
+      <li><strong>Proposals / SOWs:</strong> Engagement-specific scope, deliverables, milestones, and investment.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Engagement lifecycle</h2>
+    <ol class="timeline">
+      <li><strong>Discovery call booking</strong><br>Pay the clarity call fee, accept site terms, and receive onboarding materials.</li>
+      <li><strong>Proposal delivery</strong><br>We summarize goals, risks, deliverables, and pricing in a tartan-branded proposal. Acceptance forms the Engagement Document.</li>
+      <li><strong>Legal alignment</strong><br>Terms, Privacy Policy, Cookie Notice, and (if applicable) the Retainer Agreement govern the relationship.</li>
+      <li><strong>Delivery &amp; collaboration</strong><br>We collaborate via the Campbell Companion workspace, track time and milestones, and issue status updates.</li>
+      <li><strong>Wrap-up &amp; transition</strong><br>Final artifacts, recommendations, and next steps are packaged; post-engagement support is scheduled as needed.</li>
+    </ol>
+  </section>
+
+  <section>
+    <h2>Document applicability</h2>
+    <table class="card" style="width:100%; border-collapse:collapse;">
+      <thead>
+        <tr>
+          <th style="text-align:left; padding:0.5rem;">Document</th>
+          <th style="text-align:left; padding:0.5rem;">When it applies</th>
+          <th style="text-align:left; padding:0.5rem;">Key expectations</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td style="padding:0.5rem;"><a href="/site/legal/terms.html">Terms &amp; Conditions</a></td>
+          <td style="padding:0.5rem;">All consulting work, from booking through final deliverables.</td>
+          <td style="padding:0.5rem;">Timely access, prompt payment, confidentiality, and Virginia governing law.</td>
+        </tr>
+        <tr>
+          <td style="padding:0.5rem;"><a href="/site/legal/privacy.html">Privacy Policy</a></td>
+          <td style="padding:0.5rem;">Whenever we process personal data for marketing, booking, or engagements.</td>
+          <td style="padding:0.5rem;">Informed consent, data rights, and security commitments.</td>
+        </tr>
+        <tr>
+          <td style="padding:0.5rem;"><a href="/site/legal/cookies.html">Cookie Notice</a></td>
+          <td style="padding:0.5rem;">When you visit our website or client portals.</td>
+          <td style="padding:0.5rem;">Consent-based analytics and ability to manage preferences.</td>
+        </tr>
+        <tr>
+          <td style="padding:0.5rem;"><a href="/retainer/retainer.html">Retainer Agreement</a></td>
+          <td style="padding:0.5rem;">For ongoing monthly advisory relationships.</td>
+          <td style="padding:0.5rem;">Monthly allocation, rollover policy, status rhythm, and cancellation terms.</td>
+        </tr>
+        <tr>
+          <td style="padding:0.5rem;"><a href="/proposal/proposal.html">Proposal / SOW</a></td>
+          <td style="padding:0.5rem;">For specific initiatives, pilots, or projects.</td>
+          <td style="padding:0.5rem;">Detailed scope, deliverables, timeline, and acceptance criteria.</td>
+        </tr>
+      </tbody>
+    </table>
+  </section>
+
+  <section>
+    <h2>Working together</h2>
+    <div class="card">
+      <h3>What you can expect from us</h3>
+      <ul>
+        <li>Senior-level consulting with a bias toward actionable deliverables.</li>
+        <li>Documented architecture decisions, automation blueprints, and compliance-aware guidance.</li>
+        <li>Transparent time tracking, weekly status notes, and clear escalation paths.</li>
+        <li>Stewardship of confidential information aligned with our privacy and security commitments.</li>
+      </ul>
+    </div>
+    <div class="card" style="margin-top:1.25rem;">
+      <h3>What we need from you</h3>
+      <ul>
+        <li>A single empowered point of contact for prioritization and approvals.</li>
+        <li>Access to relevant systems, documentation, and stakeholders according to the engagement plan.</li>
+        <li>Prompt feedback on deliverables within the review windows stated in the proposal or retainer cadence.</li>
+        <li>Payment of invoices within the agreed terms and notification of any procurement requirements.</li>
+      </ul>
+    </div>
+  </section>
+
+  <section>
+    <h2>Questions &amp; escalation</h2>
+    <p>Need clarifications or custom terms? Email <a href="mailto:legal@campbellcognition.com">legal@campbellcognition.com</a> or reach your engagement lead directly. We are happy to sign mutual NDAs, provide data processing addenda, or coordinate with your compliance team.</p>
+  </section>
+</main>
+<footer class="site-footer">
+  <div class="container footer-grid">
+    <div>
+      <strong>Campbell Cognition Consultants LLC</strong><br>
+      <a href="mailto:hello@campbellcognition.com">hello@campbellcognition.com</a>
+    </div>
+    <nav>
+      <a href="/site/legal/terms.html">Terms &amp; Conditions</a>
+      <a href="/site/legal/privacy.html">Privacy Policy</a>
+      <a href="/site/legal/cookies.html">Cookie Notice</a>
+    </nav>
+    <div>
+      <strong>Proof of work</strong><br>
+      <a href="https://github.com/scottjoyner" target="_blank" rel="noopener" data-analytics-event="outbound_click" data-analytics-properties='{"destination":"github","label":"legal-summary"}'>github.com/scottjoyner</a>
+    </div>
+  </div>
+</footer>
+<script type="module" src="/site/scripts/analytics.js"></script>
+</body>
+</html>

--- a/site/legal/privacy.html
+++ b/site/legal/privacy.html
@@ -12,81 +12,113 @@
   <div class="container">
     <a class="brand" href="/site/index.html">Campbell Cognition Consultants LLC</a>
     <nav>
-      <a href="/site/offerings/">Offerings</a>
+      <a href="/site/offerings/index.html">Offerings</a>
       <a href="/site/book/">Book</a>
-      <a href="/site/sign/">Sign</a>
+      <a href="/retainer/retainer.html">Retainer</a>
+      <a href="/proposal/proposal.html">Proposal</a>
+      <a href="/site/legal/index.html">Legal Summary</a>
     </nav>
   </div>
 </header>
 <main class="container narrow">
   <h1>Privacy Policy</h1>
-  <p class="muted small">Effective 30 September 2024</p>
-  <p>This Privacy Policy explains how Campbell Cognition Consultants LLC (“Campbell Cognition,” “we,” “us,” or “our”) collects, uses, and protects personal information when you visit our website, schedule consultations, engage our services, or interact with client portals.</p>
+  <p class="muted small">Effective 1 October 2024</p>
 
-  <section>
-    <h2>1. Information We Collect</h2>
+  <section class="notice">
+    <h2>How we handle personal data</h2>
+    <p>This Privacy Policy explains how Campbell Cognition Consultants LLC (“Campbell Cognition,” “we,” “us,” or “our”) collects, uses, shares, and protects personal information when you visit our website, book consultations, receive proposals, sign retainers, or participate in client engagements.</p>
     <ul>
-      <li><strong>Contact details:</strong> name, email address, company, and role provided when booking or contacting us.</li>
-      <li><strong>Engagement data:</strong> project goals, notes, and shared artifacts necessary to deliver consulting services.</li>
-      <li><strong>Payment data:</strong> processed securely through our payment processors (e.g., Stripe); we do not store full card numbers.</li>
-      <li><strong>Analytics data:</strong> page visits, consented user actions, conversion events, and technical diagnostics captured via our Neo4j-backed analytics pipeline after you grant cookie consent.</li>
+      <li><strong>Data we collect:</strong> Contact information, engagement details, payment confirmations, analytics (when you consent), and support correspondence.</li>
+      <li><strong>How we use it:</strong> Deliver services, personalize advisory recommendations, process payments, secure systems, comply with law, and improve our offerings.</li>
+      <li><strong>Your controls:</strong> Access, correction, deletion, and consent choices as outlined below. Contact <a href="mailto:privacy@campbellcognition.com">privacy@campbellcognition.com</a> for requests.</li>
     </ul>
   </section>
 
   <section>
-    <h2>2. How We Use Information</h2>
+    <h2>1. Categories of Information We Collect</h2>
     <ul>
-      <li>Provide, operate, and improve our consulting services.</li>
-      <li>Communicate about engagements, proposals, invoices, and support.</li>
-      <li>Customize advisory recommendations and maintain engagement history.</li>
-      <li>Monitor site performance, measure conversion funnels, and improve client experiences.</li>
-      <li>Comply with legal obligations and enforce agreements.</li>
+      <li><strong>Identity &amp; contact data:</strong> Name, job title, company, email, phone number, and mailing address.</li>
+      <li><strong>Engagement data:</strong> Notes from consultations, discovery questionnaires, architecture artifacts, workflow documentation, meeting recordings (if mutually agreed), and project history.</li>
+      <li><strong>Transactional data:</strong> Payment confirmations, invoices, contract signatures, subscription selections, and related billing records.</li>
+      <li><strong>Technical &amp; analytics data:</strong> IP address, device/browser information, page interactions, and conversion events collected only after you accept cookies.</li>
+      <li><strong>Support communications:</strong> Emails, chat logs, and call summaries related to active engagements.</li>
     </ul>
   </section>
 
   <section>
-    <h2>3. How We Share Information</h2>
+    <h2>2. Sources of Information</h2>
+    <p>We obtain information directly from you, from your authorized teammates, from publicly available sources (e.g., professional profiles), and from trusted vendors that you connect to our workflows (such as Stripe, Google Calendar, Notion, or n8n integrations).</p>
+  </section>
+
+  <section>
+    <h2>3. Purposes &amp; Legal Bases</h2>
+    <p>We process personal information for the following purposes:</p>
     <ul>
-      <li>With trusted subprocessors (e.g., payment providers, calendar integrations) necessary to deliver services.</li>
-      <li>With legal or regulatory authorities when required by law or to protect our rights.</li>
-      <li>Within our company and trusted advisors bound by confidentiality obligations.</li>
-      <li>We do not sell personal information.</li>
+      <li><strong>Delivering services:</strong> Performing contractual obligations, including onboarding, discovery, architecture reviews, and automation design.</li>
+      <li><strong>Billing &amp; administration:</strong> Processing payments, managing invoices, and maintaining accurate records (contractual necessity and legitimate interests).</li>
+      <li><strong>Communications:</strong> Sending proposals, project updates, service announcements, and security notifications (contractual necessity and legitimate interests).</li>
+      <li><strong>Analytics &amp; improvement:</strong> Measuring funnel metrics, product adoption, and site performance when you consent to cookies (consent and legitimate interests).</li>
+      <li><strong>Legal &amp; compliance:</strong> Satisfying legal obligations, responding to lawful requests, enforcing agreements, and preventing fraud (legal obligation and legitimate interests).</li>
     </ul>
   </section>
 
   <section>
-    <h2>4. Data Retention</h2>
-    <p>We retain engagement information for the duration of the client relationship and as required for legal, accounting, or compliance purposes. Analytics data is retained to understand long-term trends and improve offerings; you may request deletion as described below.</p>
+    <h2>4. Sharing &amp; Disclosure</h2>
+    <p>We share personal information with:</p>
+    <ul>
+      <li><strong>Authorized team members and subcontractors</strong> who assist with consulting engagements under confidentiality obligations.</li>
+      <li><strong>Trusted service providers</strong> such as Stripe (payments), Google (calendar and productivity), Notion (client workspaces), Neo4j (analytics datastore), n8n (automation workflows), and secure document-signing services.</li>
+      <li><strong>Professional advisors</strong> (legal, accounting, insurance) bound by confidentiality, when necessary.</li>
+      <li><strong>Regulators or law enforcement</strong> when required by law or to protect our rights.</li>
+    </ul>
+    <p>We never sell personal information.</p>
   </section>
 
   <section>
-    <h2>5. Your Rights</h2>
-    <p>Depending on your jurisdiction, you may have rights to access, correct, or delete personal information, and to object to or restrict certain processing. Submit requests to <a href="mailto:privacy@campbellcognition.com">privacy@campbellcognition.com</a> and we will respond within 30 days.</p>
+    <h2>5. Data Retention</h2>
+    <p>We retain personal information for as long as needed to deliver services, comply with legal obligations, resolve disputes, and enforce agreements. Retainer workpapers and architectural artifacts are typically stored for 24 months after the engagement unless you request earlier deletion or ongoing support requires longer retention. Invoices and contractual records may be stored for up to seven (7) years to meet accounting requirements.</p>
   </section>
 
   <section>
-    <h2>6. Cookies &amp; Consent Management</h2>
-    <p>We use essential cookies for site functionality and optional analytics cookies when you grant consent via our on-site cookie banner. Analytics events are stored in Neo4j and used to compute visitors, conversion rates, and product adoption metrics. You can withdraw consent at any time by clearing your browser storage or contacting us.</p>
+    <h2>6. Security Measures</h2>
+    <p>We employ administrative, technical, and physical safeguards including principle-of-least-privilege access, mandatory multi-factor authentication, encrypted transports (TLS), regular vulnerability reviews, and documented incident response procedures. Notify us immediately at <a href="mailto:security@campbellcognition.com">security@campbellcognition.com</a> if you suspect unauthorized access.</p>
   </section>
 
   <section>
-    <h2>7. Security</h2>
-    <p>We employ administrative, technical, and physical safeguards (including access controls, encryption-in-transit, and audit logs) to protect information. No method is 100% secure; notify us immediately at <a href="mailto:security@campbellcognition.com">security@campbellcognition.com</a> if you suspect unauthorized access.</p>
+    <h2>7. International Data Transfers</h2>
+    <p>We operate primarily in the United States. If information is transferred internationally, we rely on appropriate safeguards such as Standard Contractual Clauses or other transfer mechanisms recognized by applicable data protection laws.</p>
   </section>
 
   <section>
-    <h2>8. International Transfers</h2>
-    <p>We operate primarily within the United States. If we transfer information across borders, we do so under appropriate safeguards consistent with applicable laws.</p>
+    <h2>8. Your Rights &amp; Choices</h2>
+    <p>Depending on your jurisdiction, you may have rights to:</p>
+    <ul>
+      <li>Access, correct, or delete personal information we maintain about you.</li>
+      <li>Restrict or object to certain processing, including analytics based on cookies.</li>
+      <li>Receive a copy of your information in a portable format.</li>
+      <li>Withdraw consent for analytics cookies at any time without affecting the lawfulness of processing before withdrawal.</li>
+    </ul>
+    <p>Submit requests to <a href="mailto:privacy@campbellcognition.com">privacy@campbellcognition.com</a>. We respond within 30 days, subject to identity verification.</p>
   </section>
 
   <section>
-    <h2>9. Updates</h2>
-    <p>We may update this Privacy Policy periodically. Material changes will be posted on this page with an updated effective date.</p>
+    <h2>9. Children</h2>
+    <p>Our services are intended for business clients. We do not knowingly collect information from children under 16. If you believe a child has provided personal information, contact us so we can delete it.</p>
   </section>
 
   <section>
-    <h2>10. Contact</h2>
-    <p>For privacy questions or requests, contact <a href="mailto:privacy@campbellcognition.com">privacy@campbellcognition.com</a>.</p>
+    <h2>10. Third-Party Links &amp; Integrations</h2>
+    <p>Our website and deliverables may include links to third-party resources or integrations. We encourage you to review the privacy policies of those services, as their practices are independent of ours.</p>
+  </section>
+
+  <section>
+    <h2>11. Updates to this Policy</h2>
+    <p>We may update this Privacy Policy to reflect changes in our practices or legal requirements. Material changes will be posted here with an updated effective date and, where feasible, additional notice (such as email or portal announcements).</p>
+  </section>
+
+  <section>
+    <h2>12. Contact</h2>
+    <p>For privacy questions or requests, email <a href="mailto:privacy@campbellcognition.com">privacy@campbellcognition.com</a> or write to Campbell Cognition Consultants LLC, 8280 Willow Oaks Corporate Dr., Suite 600, Fairfax, VA 22031 USA.</p>
   </section>
 </main>
 <footer class="site-footer">
@@ -96,9 +128,9 @@
       <a href="mailto:hello@campbellcognition.com">hello@campbellcognition.com</a>
     </div>
     <nav>
+      <a href="/site/legal/index.html">Legal Summary</a>
       <a href="/site/legal/terms.html">Terms &amp; Conditions</a>
       <a href="/site/legal/cookies.html">Cookie Notice</a>
-      <a href="/site/index.html">Back to Home</a>
     </nav>
     <div>
       <strong>Proof of work</strong><br>

--- a/site/legal/terms.html
+++ b/site/legal/terms.html
@@ -12,84 +12,160 @@
   <div class="container">
     <a class="brand" href="/site/index.html">Campbell Cognition Consultants LLC</a>
     <nav>
-      <a href="/site/offerings/">Offerings</a>
+      <a href="/site/offerings/index.html">Offerings</a>
       <a href="/site/book/">Book</a>
-      <a href="/site/sign/">Sign</a>
+      <a href="/retainer/retainer.html">Retainer</a>
+      <a href="/proposal/proposal.html">Proposal</a>
+      <a href="/site/legal/index.html">Legal Summary</a>
     </nav>
   </div>
 </header>
 <main class="container narrow">
   <h1>Terms &amp; Conditions</h1>
-  <p class="muted small">Effective 30 September 2024</p>
-  <p>These Terms &amp; Conditions (“Terms”) govern your use of the services provided by Campbell Cognition Consultants LLC (“Campbell Cognition,” “we,” “us,” or “our”). By booking a consultation, purchasing a retainer, or collaborating with us on an engagement, you agree to these Terms.</p>
+  <p class="muted small">Effective 1 October 2024</p>
 
-  <section>
-    <h2>1. Services</h2>
-    <p>We provide architecture advisory, AI integration support, automation design, and related consulting services as described on our website, proposals, and statements of work (SOWs). Specific deliverables, timelines, and responsibilities will be defined in the SOW or engagement letter for each project.</p>
+  <section class="notice">
+    <h2>How to use these Terms</h2>
+    <p>These Terms &amp; Conditions (the “Terms”) are the master agreement between Campbell Cognition Consultants LLC (“Campbell Cognition,” “we,” “us,” or “our”) and the client entity that books, signs, or pays for our services (“Client,” “you,” or “your”). They work together with any proposal, statement of work (SOW), or retainer order form (each an “Engagement Document”).</p>
+    <ul>
+      <li><strong>Order of precedence:</strong> Engagement Documents &gt; these Terms &gt; any ancillary policies referenced herein.</li>
+      <li><strong>Document stack:</strong> Terms, <a href="/site/legal/privacy.html">Privacy Policy</a>, <a href="/site/legal/cookies.html">Cookie Notice</a>, and any signed Engagement Document or retainer plan.</li>
+      <li><strong>Expectations:</strong> You provide timely information and approvals, we deliver scoped services with professional care, and both parties safeguard confidential data and comply with law.</li>
+    </ul>
+    <p class="small muted">By booking a clarity call, signing a proposal, paying an invoice, or otherwise accepting an Engagement Document, you agree to these Terms.</p>
   </section>
 
   <section>
-    <h2>2. Booking and Payments</h2>
+    <h2>1. Engagement Workflow &amp; Formation</h2>
+    <p>Our standard workflow consists of (a) booking a paid introductory consultation, (b) receiving a written proposal with scope, deliverables, fees, and assumptions, and (c) confirming an Engagement Document (proposal acceptance, SOW, or retainer order form). The agreement between the parties is formed when you accept an Engagement Document, pay an invoice, or provide written authorization to proceed.</p>
+  </section>
+
+  <section>
+    <h2>2. Services</h2>
+    <p>We provide architecture advisory, AI integration support, workflow automation design, and related consulting services. Specific deliverables, acceptance criteria, and timelines are defined in the applicable Engagement Document. We may recommend third-party services or vendors but do not warrant their offerings.</p>
+  </section>
+
+  <section>
+    <h2>3. Retainers &amp; Time Usage</h2>
     <ul>
-      <li>Introductory consultations are prepaid through our secure checkout and are non-refundable once delivered.</li>
-      <li>Retainer engagements renew monthly unless canceled according to the notice period in your SOW.</li>
-      <li>Invoices for project work are due upon receipt unless otherwise stated. Late payments may incur interest at the maximum rate permitted by law.</li>
-      <li>We reserve the right to suspend services for accounts that are past due.</li>
+      <li>Retainer plans provide a monthly allocation of advisory hours, workshops, and deliverables described in the order form.</li>
+      <li>Unused hours expire at the end of each retainer month unless otherwise specified. We may, at our discretion, roll over up to 25% of unused time.</li>
+      <li>Time is tracked in 30-minute increments and reported via the client portal or periodic summaries.</li>
     </ul>
   </section>
 
   <section>
-    <h2>3. Client Responsibilities</h2>
+    <h2>4. Fees, Expenses &amp; Payment</h2>
     <ul>
-      <li>Provide accurate information, timely access, and necessary approvals so we can perform the services.</li>
-      <li>Ensure that any materials you provide do not infringe third-party rights and comply with applicable laws.</li>
-      <li>Maintain appropriate security controls for your systems, credentials, and data.</li>
+      <li>Fees are set out in the Engagement Document. All amounts are quoted in U.S. dollars unless stated otherwise.</li>
+      <li>Invoices are due upon receipt and payable within 15 calendar days via ACH transfer, credit card, or other agreed method. Late payments accrue interest at 1.5% per month (or the maximum legal rate if lower).</li>
+      <li>You are responsible for reasonable, pre-approved travel or third-party expenses incurred on your behalf. We will provide supporting documentation upon request.</li>
+      <li>We may suspend services for accounts that are more than 15 days past due after written notice.</li>
     </ul>
   </section>
 
   <section>
-    <h2>4. Confidentiality</h2>
-    <p>We treat your confidential information with care and use it solely to deliver the services. Each party agrees to protect the other party’s confidential information with at least the same degree of care it uses to protect its own, and not to disclose it to any third party without prior written consent except as required by law.</p>
+    <h2>5. Change Management</h2>
+    <p>Material changes to scope, timeline, or assumptions require a written change order or updated Engagement Document. We will notify you if requested work exceeds the agreed scope and provide options before proceeding.</p>
   </section>
 
   <section>
-    <h2>5. Intellectual Property</h2>
-    <p>Unless otherwise specified in your SOW, you own the deliverables we create specifically for you once payment is complete. We retain ownership of our pre-existing materials, methodologies, templates, and know-how, but grant you a non-exclusive license to use them as part of the deliverables.</p>
+    <h2>6. Client Responsibilities</h2>
+    <ul>
+      <li>Provide timely access to stakeholders, systems, documentation, and subject-matter experts.</li>
+      <li>Designate a primary point of contact empowered to review and accept deliverables.</li>
+      <li>Ensure materials you supply do not infringe third-party rights and comply with applicable laws and policies.</li>
+      <li>Maintain appropriate security controls and backups for your infrastructure and data.</li>
+    </ul>
   </section>
 
   <section>
-    <h2>6. Compliance &amp; Security</h2>
-    <p>We design engagements to respect your compliance obligations (including SOC 2, HIPAA, GDPR, and other regulatory regimes). You are responsible for informing us of any additional requirements before an engagement begins. We do not guarantee regulatory approval, but we provide documentation and design decisions to support your review processes.</p>
+    <h2>7. Confidentiality</h2>
+    <p>Each party may disclose confidential information to the other during the engagement. The receiving party will protect the disclosing party’s confidential information with at least the same degree of care it uses for its own (and no less than reasonable care), use it solely to perform obligations under the engagement, and not disclose it to third parties except to permitted subcontractors or advisors bound by similar obligations. These obligations continue for five (5) years after disclosure, or indefinitely for trade secrets.</p>
   </section>
 
   <section>
-    <h2>7. Warranties &amp; Disclaimer</h2>
-    <p>We warrant that we will perform the services in a professional and workmanlike manner consistent with industry standards. Except as expressly stated in these Terms, we disclaim all other warranties, including implied warranties of merchantability, fitness for a particular purpose, and non-infringement. We do not guarantee specific business results or outcomes.</p>
+    <h2>8. Data Protection &amp; Security</h2>
+    <p>We handle personal data in accordance with our Privacy Policy and applicable data protection laws. Where required, the parties will execute data processing addenda or business associate agreements. Each party will promptly notify the other of any confirmed unauthorized access to the other party’s confidential information and cooperate in remediation.</p>
   </section>
 
   <section>
-    <h2>8. Limitation of Liability</h2>
-    <p>Our total liability for any claim arising out of or relating to the services is limited to the amounts you paid to us for the services giving rise to the claim within the 12 months preceding the event. We are not liable for indirect, consequential, incidental, punitive, or special damages.</p>
+    <h2>9. Intellectual Property</h2>
+    <ul>
+      <li>You retain ownership of your pre-existing materials and data. We retain ownership of our pre-existing tools, frameworks, and know-how.</li>
+      <li>Upon full payment of fees, you receive a worldwide, perpetual, royalty-free license to use, reproduce, and modify the deliverables created specifically for you during the engagement for your internal business purposes.</li>
+      <li>We may reuse generalized knowledge, ideas, or non-confidential learnings developed while providing services.</li>
+    </ul>
   </section>
 
   <section>
-    <h2>9. Termination</h2>
-    <p>Either party may terminate an engagement for material breach that remains uncured after 14 days’ written notice. Upon termination you agree to pay for all services rendered through the effective termination date. Sections relating to confidentiality, intellectual property, payment obligations, and limitations of liability survive termination.</p>
+    <h2>10. Publicity &amp; Portfolio Use</h2>
+    <p>We may list your company name and logo as a client in marketing materials only with your prior written consent. Testimonials or case studies require separate approval.</p>
   </section>
 
   <section>
-    <h2>10. Governing Law</h2>
-    <p>These Terms are governed by the laws of the Commonwealth of Virginia, without regard to its conflict of laws principles. Any disputes will be resolved in the state or federal courts located in Fairfax County, Virginia, and the parties consent to personal jurisdiction there.</p>
+    <h2>11. Compliance</h2>
+    <p>We will use commercially reasonable efforts to align our work with your regulatory obligations (including SOC 2, HIPAA, GDPR, or other regimes identified in the Engagement Document). You are responsible for informing us of any mandatory requirements and for your own compliance determinations.</p>
   </section>
 
   <section>
-    <h2>11. Changes</h2>
-    <p>We may update these Terms from time to time. When we make material changes, we will update the effective date above and post the revised Terms on this page. Continued use of our services after changes take effect constitutes acceptance of the updated Terms.</p>
+    <h2>12. Warranties</h2>
+    <p>We warrant that we will perform the services in a professional and workmanlike manner consistent with industry standards. We further warrant that we have the right to grant the licenses described in these Terms. EXCEPT FOR THE EXPRESS WARRANTIES IN THIS SECTION, THE SERVICES ARE PROVIDED “AS IS.” WE DISCLAIM ALL IMPLIED WARRANTIES, INCLUDING MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NON-INFRINGEMENT.</p>
   </section>
 
   <section>
-    <h2>12. Contact</h2>
-    <p>Questions about these Terms can be sent to <a href="mailto:hello@campbellcognition.com">hello@campbellcognition.com</a>.</p>
+    <h2>13. Limitation of Liability</h2>
+    <p>To the fullest extent permitted by law, each party’s total liability arising out of or relating to an engagement is limited to the fees paid or payable by you for the services giving rise to the claim in the twelve (12) months preceding the event. Neither party is liable for indirect, consequential, incidental, punitive, exemplary, or special damages, including lost profits, revenue, or data.</p>
+  </section>
+
+  <section>
+    <h2>14. Indemnification</h2>
+    <p>Each party will indemnify and defend the other against third-party claims to the extent arising from the indemnifying party’s (a) gross negligence or willful misconduct, (b) violation of law, or (c) infringement of intellectual property rights by materials the indemnifying party provides. The indemnified party will promptly notify the indemnifying party of claims, allow control of the defense, and cooperate at the indemnifying party’s expense.</p>
+  </section>
+
+  <section>
+    <h2>15. Term &amp; Termination</h2>
+    <p>These Terms remain in effect for as long as any Engagement Document is active. Either party may terminate an engagement for material breach that remains uncured 14 days after written notice. Either party may terminate a retainer by providing 30 days’ written notice after the initial commitment period specified in the order form. Upon termination, you will pay for services performed and approved expenses incurred through the effective termination date.</p>
+  </section>
+
+  <section>
+    <h2>16. Effect of Termination</h2>
+    <p>Upon termination, each party will return or destroy the other’s confidential information, subject to archival copies required by law. Sections relating to payment, confidentiality, data protection, intellectual property, limitations of liability, indemnification, and governing law survive termination.</p>
+  </section>
+
+  <section>
+    <h2>17. Independent Contractor &amp; Subcontractors</h2>
+    <p>We are an independent contractor. Nothing creates a partnership, joint venture, fiduciary, or employment relationship. We may use vetted subcontractors or affiliates to deliver portions of the services; we remain responsible for their performance.</p>
+  </section>
+
+  <section>
+    <h2>18. Non-Solicitation</h2>
+    <p>During the engagement and for six (6) months after its conclusion, neither party will solicit for employment any personnel of the other directly involved in providing or receiving the services, except through general solicitations not specifically targeting such personnel.</p>
+  </section>
+
+  <section>
+    <h2>19. Force Majeure</h2>
+    <p>Neither party is liable for failure to perform due to events beyond its reasonable control, including natural disasters, war, terrorism, labor disputes, government actions, or widespread service outages, provided that the affected party gives prompt notice and resumes performance as soon as practicable.</p>
+  </section>
+
+  <section>
+    <h2>20. Governing Law &amp; Dispute Resolution</h2>
+    <p>These Terms are governed by the laws of the Commonwealth of Virginia without regard to conflict of law principles. The parties consent to exclusive jurisdiction and venue in the state and federal courts located in Fairfax County, Virginia. The parties agree to attempt good-faith negotiation for at least 15 days before initiating litigation.</p>
+  </section>
+
+  <section>
+    <h2>21. Notices</h2>
+    <p>Formal notices must be sent by email to <a href="mailto:legal@campbellcognition.com">legal@campbellcognition.com</a> with a copy to hello@campbellcognition.com, and to the contact email or address you designate in the Engagement Document.</p>
+  </section>
+
+  <section>
+    <h2>22. Miscellaneous</h2>
+    <p>If any provision of these Terms is held unenforceable, the remaining provisions remain in full force. Neither party may assign the engagement without the other’s written consent, except that either party may assign to an affiliate or successor in interest in connection with a merger or sale of substantially all assets. These Terms, together with the Engagement Documents and referenced policies, are the entire agreement between the parties regarding the services.</p>
+  </section>
+
+  <section>
+    <h2>23. Contact</h2>
+    <p>Questions about these Terms may be sent to <a href="mailto:hello@campbellcognition.com">hello@campbellcognition.com</a>.</p>
   </section>
 </main>
 <footer class="site-footer">
@@ -99,9 +175,9 @@
       <a href="mailto:hello@campbellcognition.com">hello@campbellcognition.com</a>
     </div>
     <nav>
+      <a href="/site/legal/index.html">Legal Summary</a>
       <a href="/site/legal/privacy.html">Privacy Policy</a>
       <a href="/site/legal/cookies.html">Cookie Notice</a>
-      <a href="/site/index.html">Back to Home</a>
     </nav>
     <div>
       <strong>Proof of work</strong><br>


### PR DESCRIPTION
## Summary
- Replace the legal center with comprehensive Terms & Conditions, Privacy Policy, and Cookie Notice that spell out workflow usage, responsibilities, and compliance support.
- Add a legal summary page plus refreshed retainer and proposal templates so engagements include clear expectations, cadence, and acceptance language.
- Link the marketing site navigation to the new legal overview for easy access to the updated documents.

## Testing
- Not run (static content changes).

------
https://chatgpt.com/codex/tasks/task_e_68dc32cc05dc8325a781549a5032d37f